### PR TITLE
handler_test.go: allow extra headers

### DIFF
--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -135,7 +135,7 @@ func (s *ProxyHappySuite) TestPingCarriesServerHeadersAndTrailers() {
 	out, err := s.testClient.Ping(s.ctx(), &pb.PingRequest{Value: "foo"}, grpc.Header(&headerMd), grpc.Trailer(&trailerMd))
 	require.NoError(s.T(), err, "Ping should succeed without errors")
 	require.Equal(s.T(), &pb.PingResponse{Value: "foo", Counter: 42}, out)
-	assert.Len(s.T(), headerMd, 1, "server response headers must contain server data")
+	assert.Contains(s.T(), headerMd, serverHeaderMdKey, "server response headers must contain server data")
 	assert.Len(s.T(), trailerMd, 1, "server response trailers must contain server data")
 }
 
@@ -170,7 +170,7 @@ func (s *ProxyHappySuite) TestPingStream_FullDuplexWorks() {
 			// Check that the header arrives before all entries.
 			headerMd, err := stream.Header()
 			require.NoError(s.T(), err, "PingStream headers should not error.")
-			assert.Len(s.T(), headerMd, 1, "PingStream response headers user contain metadata")
+			assert.Contains(s.T(), headerMd, serverHeaderMdKey, "PingStream response headers user contain metadata")
 		}
 		assert.EqualValues(s.T(), i, resp.Counter, "ping roundtrip must succeed with the correct id")
 	}


### PR DESCRIPTION
The current gRPC seems to add a "content-type" header automatically,
causing the tests to fail with:

    --- FAIL: TestProxyHappySuite/TestPingCarriesServerHeadersAndTrailers (0.00s)
    	handler_test.go:138:
    			Error Trace:	handler_test.go:138
    			Error:      	"map[test-client-header:[I like turtles.] content-type:[application/grpc]]" should have 1 item(s), but has 2
    			Test:       	TestProxyHappySuite/TestPingCarriesServerHeadersAndTrailers
    			Messages:   	server response headers must contain server data
    --- FAIL: TestProxyHappySuite/TestPingStream_FullDuplexWorks (0.01s)
    	handler_test.go:173:
    			Error Trace:	handler_test.go:173
    			Error:      	"map[content-type:[application/grpc] test-client-header:[I like turtles.]]" should have 1 item(s), but has 2
    			Test:       	TestProxyHappySuite/TestPingStream_FullDuplexWorks
    			Messages:   	PingStream response headers user contain metadata

Instead of checking the length and assuming that the header is the
right one, now these two lines check for the existence of the
"test-client-header" header.